### PR TITLE
adsense-component-named-export

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Let Google's Auto Ads intelligently place ads on your page. This is the easiest 
 
 ```jsx
 import React from "react";
-import AdSense from "google-adsense";
+import {AdSense} from "google-adsense";
 
 const App = () => {
   return (
@@ -47,7 +47,7 @@ For more control, you can specify the exact placement of your ads using ad slots
 
 ```jsx
 import React from "react";
-import AdSense from "google-adsense";
+import {AdSense} from "google-adsense";
 
 const App = () => {
   return (


### PR DESCRIPTION
Adsense component was not expert default and in package it is used as named export so i add curly braces on function import

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests Pass
- [ ] The appropriate changes to README are included in PR
